### PR TITLE
support git version <= 1.8.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,11 +65,11 @@ function determineBuildId (id, inputDir) {
   if (id) return Promise.resolve(id)
   return new Promise((resolve, reject) => {
     const cp = require('child_process')
-    cp.execFile('git', ['-C', inputDir, 'rev-parse', 'HEAD'], (err, stdout, stderr) => {
+    cp.execFile('git', [`--git-dir=${inputDir}/.git`, `--work-tree=${inputDir}`, 'rev-parse', 'HEAD'], (err, stdout, stderr) => {
       if (err) return reject(err)
       if (stderr) return reject(String(stderr).trim())
       if (stdout) return resolve(String(stdout).trim())
-      reject(`No output from command: git -C ${inputDir} rev-parse HEAD`)
+      reject(`No output from command: git --git-dir=${inputDir}/.git --work-tree=${inputDir} rev-parse HEAD`)
     })
   })
 }


### PR DESCRIPTION
``-C`` option is available >= 1.8.5, but CentOS 6/7's default git version is 1.8.3.
This PR add support for CentOS default git command.