### PR TITLE
chore: upgrade dependencies, 20180407 edition

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "coveralls": "^3.0.0",
     "rimraf": "^2.6.2",
-    "standard": "^10.0.3",
+    "standard": "^11.0.1",
     "standard-version": "^4.3.0",
     "tap": "^11.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "coveralls": "^3.0.0",
     "rimraf": "^2.6.2",
     "standard": "^10.0.3",
-    "standard-version": "^4.2.0",
-    "tap": "^11.0.0"
+    "standard-version": "^4.3.0",
+    "tap": "^11.1.3"
   }
 }

--- a/test/fixture/package.json
+++ b/test/fixture/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "next": "^4.2.1",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "next": "^4.2.3",
+    "react": "^16.3.1",
+    "react-dom": "^16.3.1"
   }
 }


### PR DESCRIPTION
Just a couple minor version bumps for dev deps.

Keep testing with `next` v4 for now. Will handle the v5 upgrade later.