### PR TITLE
feat: support Next.js v5 and "config as a function"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test/fixture/.next/
 test/fixture/nextoutput/
 test/fixture/next.config.js
 test/fixture2/.next/BUILD_ID
+test/fixture-next5/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ node_js:
   - 'node'
   - '8'
   - '6'
-  - '4'
 after_success: npm run coverage

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const defaultConfig = {
   assetPrefix: '',
   configOrigin: 'default',
   useFileSystemPublicRoutes: true,
-  generateBuildId: () => '9f2a37be-4545-445e-91bd-' + String(new Date().getTime()).slice(1, 13),
+  // generateBuildId: () => '9f2a37be-4545-445e-91bd-' + String(new Date().getTime()).slice(1, 13),
   generateEtags: true,
   pageExtensions: ['jsx', 'js']
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "rimraf": "^2.6.2",
     "standard": "^11.0.1",
     "standard-version": "^4.4.0",
-    "tap": "^11.1.3"
+    "tap": "^12.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "sywac": "^1.2.0"
   },
   "devDependencies": {
-    "coveralls": "^3.0.0",
+    "coveralls": "^3.0.1",
     "rimraf": "^2.6.2",
     "standard": "^11.0.1",
-    "standard-version": "^4.3.0",
+    "standard-version": "^4.4.0",
     "tap": "^11.1.3"
   }
 }

--- a/test/fixture-next5/next.config.js
+++ b/test/fixture-next5/next.config.js
@@ -1,0 +1,24 @@
+const withPlugins = require('next-compose-plugins')
+const images = require('next-images')
+const sass = require('@zeit/next-sass')
+
+// next.js configuration
+const nextConfig = {
+  useFileSystemPublicRoutes: false,
+  distDir: 'build'
+}
+
+module.exports = withPlugins([
+
+  // add a plugin with specific configuration
+  [sass, {
+    cssModules: true,
+    cssLoaderOptions: {
+      localIdentName: '[local]___[hash:base64:5]'
+    }
+  }],
+
+  // add a plugin without a configuration
+  images
+
+], nextConfig)

--- a/test/fixture-next5/package.json
+++ b/test/fixture-next5/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "fixture",
+  "version": "1.0.0",
+  "description": "Fixture to test against Next.js 5",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "build": "next build"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@zeit/next-sass": "^0.2.0",
+    "next": "^5.1.0",
+    "next-compose-plugins": "^2.1.1",
+    "next-images": "^0.10.2",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2"
+  }
+}

--- a/test/fixture-next5/pages/index.js
+++ b/test/fixture-next5/pages/index.js
@@ -1,0 +1,1 @@
+export default () => <div>Welcome to next.js!</div>

--- a/test/test-next5.js
+++ b/test/test-next5.js
@@ -1,0 +1,43 @@
+const path = require('path')
+
+const tap = require('tap')
+const rimraf = require('rimraf')
+
+const utils = require('./utils')
+
+const exec = utils.exec
+const cli = utils.cli
+const readTextFile = utils.readTextFile
+const fixturePath = path.resolve(__dirname, 'fixture-next5')
+
+let npmi = false
+tap.beforeEach(() => {
+  if (npmi) return Promise.resolve()
+  npmi = true
+  return exec('npm', 'i', fixturePath)
+})
+
+tap.afterEach(() => {
+  return Promise.all(['build'].map(dir => {
+    return new Promise((resolve, reject) => {
+      rimraf(path.resolve(fixturePath, dir), err => {
+        if (err) return reject(err)
+        resolve()
+      })
+    })
+  }))
+})
+
+tap.test('with next.config.js that exports a function', t => {
+  return exec('npm', 'run build', fixturePath).then(() => {
+    return cli('', fixturePath)
+  }).then(io => {
+    t.notOk(io.err)
+    t.notOk(io.stderr)
+    t.match(io.stdout, /Build ID: 0123456789abcdef0123456789abcdef01234567/)
+    t.match(io.stdout, /Updated:.*BUILD_ID/)
+    return readTextFile(path.resolve(fixturePath, 'build', 'BUILD_ID'))
+  }).then(buildId => {
+    t.equal(buildId, '0123456789abcdef0123456789abcdef01234567')
+  })
+})


### PR DESCRIPTION
Support Next 5, specifically the ability to define the next.config.js module as a function, which was brought up in #4.

Also drop Node 4 from testing/maintenance since it is past EOL.

Also bump dependencies.