### PR TITLE
fix: look for .git dir in parents of input dir

### DIFF
--- a/test/git
+++ b/test/git
@@ -1,4 +1,12 @@
 #!/usr/bin/env node
-if (!String(process.argv[3]).includes('fixture3')) {
-  console.log('0123456789abcdef0123456789abcdef01234567')
-}
+
+// --git-dir=${inputDir}/.git --work-tree=${inputDir}
+require('sywac')
+  .dir('--git-dir <dir>', { mustExist: true })
+  .outputSettings({ showHelpOnError: false })
+  .parseAndExit()
+  .then(argv => {
+    if (!process.env.NBI_TEST_FIXTURE || !String(process.env.NBI_TEST_FIXTURE).includes('fixture3')) {
+      console.log('0123456789abcdef0123456789abcdef01234567')
+    }
+  })

--- a/test/test-fixture.js
+++ b/test/test-fixture.js
@@ -88,7 +88,7 @@ tap.test('supports custom --id', t => {
 
 tap.test('does not need git with custom --id', t => {
   return exec('npm', 'run build', fixturePath).then(() => {
-    return cli('--id 123456', fixturePath, '/dne')
+    return cli('--id 123456', fixturePath, { PATH: '/dne' })
   }).then(io => {
     t.notOk(io.err)
     t.notOk(io.stderr)

--- a/test/test-others.js
+++ b/test/test-others.js
@@ -21,7 +21,7 @@ tap.test('errs on invalid json', t => {
 })
 
 tap.test('errs on no git output', t => {
-  return cli('', path.resolve(__dirname, 'fixture3')).then(io => {
+  return cli('', path.resolve(__dirname, 'fixture3'), { NBI_TEST_FIXTURE: 'fixture3' }).then(io => {
     t.equal(io.err.code, 1)
     t.match(io.stderr, /No output from command: git/)
     t.notOk(io.stdout)
@@ -29,7 +29,7 @@ tap.test('errs on no git output', t => {
 })
 
 tap.test('errs without --id and without git', t => {
-  return cli('', path.resolve(__dirname, 'fixture3'), '/dne').then(io => {
+  return cli('', path.resolve(__dirname, 'fixture3'), { NBI_TEST_FIXTURE: 'fixture3', PATH: '/dne' }).then(io => {
     t.equal(io.err.code, 1)
     t.match(io.stderr, /Unexpected error/)
     t.notOk(io.stdout)

--- a/test/utils.js
+++ b/test/utils.js
@@ -21,14 +21,14 @@ function exec (file, args, cwd, env, alwaysResolve) {
   })
 }
 
-function mockedGitEnv (envPath) {
-  const env = Object.assign({}, process.env)
-  env.PATH = envPath || [__dirname].concat(env.PATH.split(path.delimiter)).join(path.delimiter)
-  return env
+function mockedGitEnv (env) {
+  env = env || {}
+  if (!env.PATH) env.PATH = [__dirname].concat(process.env.PATH.split(path.delimiter)).join(path.delimiter)
+  return Object.assign({}, process.env, env)
 }
 
-function cli (args, cwd, envPath) {
-  return exec(cliPath, args, cwd, mockedGitEnv(envPath), true)
+function cli (args, cwd, env) {
+  return exec(cliPath, args, cwd, mockedGitEnv(env), true)
 }
 
 function readTextFile (file) {


### PR DESCRIPTION
PR #2 changed the git command used by next-build-id from using the `-C` flag to using the `--git-dir` and `--work-tree` flags, which are more strict in the sense that if the directory path given does not exist, git will fail, whereas the `-C` flag will work for any subdirectory within a git project.

Unfortunately the test suite for next-build-id was not smart enough to accurately mimic this git behavior, so the problem was unknown until I started using an upgraded version of this lib.

This PR fixes that regression by:
1. Changing the logic that issues the git command to first find the parent directory that contains a valid `.git` dir (if it exists) before calling the git command
2. Improving the mocked git command for tests such that it will fail if the `--git-dir` path does not exist